### PR TITLE
Allow encrypt to take pubkey as a parameter

### DIFF
--- a/syft/nn/linear.py
+++ b/syft/nn/linear.py
@@ -24,12 +24,15 @@ class LinearClassifier(object):
         self.encrypted = False
         self.capsule = capsule_client
 
-    def encrypt(self):
+    def encrypt(self, pubkey=None):
         """iterates through each weight and encrypts it
 
         TODO: check that weights are actually decrypted
         """
-        self.pubkey = self.capsule.keygen()
+        if pubkey is not None:
+            self.pubkey = pubkey
+        else:
+            self.pubkey = self.capsule.keygen()
         self.encrypted = True
         self.weights = self.weights.encrypt(self.pubkey)
         return self


### PR DESCRIPTION
Allow encrypt to take pubkey as a parameter instead of always generating a new one